### PR TITLE
fix CircleCI cache key mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
 
       - run: npm start
       - store_artifacts:


### PR DESCRIPTION
Since the retrieval of cache is 'prefix-matched' (https://circleci.com/docs/2.0/caching/#restoring-cache), currently L16 (`v1-dependencies-{{ checksum "package-lock.json" }}`) have no effect.

Another solution might be:
```diff
      - restore_cache:
          keys:
-         - v1-dependencies-{{ checksum "package-lock.json" }}
+         - v1-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
+         - v1-dependencies-{{ .Branch }}-
          - v1-dependencies-
```
... but the branch name doesn't seem to be relevant in this case.